### PR TITLE
Updates function name for mybb 1.8

### DIFF
--- a/inc/plugins/spamalyser/sp_main.php
+++ b/inc/plugins/spamalyser/sp_main.php
@@ -891,7 +891,7 @@ function spamalyser_report_post($pid, $thresh) {
 		'reportstatus' => 0,
 		'reason' => $db->escape_string($lang->sprintf($lang->spamalyser_report_msg, $thresh))
 	));
-	$GLOBALS['cache']->update_reportedposts();
+	$GLOBALS['cache']->update_reportedcontent();
 	return true;
 }
 


### PR DESCRIPTION
Commit https://github.com/mmikeww/mybb-spamalyser/commit/8115746b3f6aed74c4639a006135ba55658bc0ed updates `reportedposts` to `reportedcontent` as required for mybb 1.8. 

This pull request updates the function name  on line 894 to also reflect the correct name for mybb 1.8. 

The change is required due to this commit in the mybb repo:

https://github.com/mybb/mybb/commit/f4eec212e1a13d01b057b411b10251dd776116b4